### PR TITLE
Switch website files to CC-BY 4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # INTERMAGNET Organization Pages
 
-<a rel="license" href="http://creativecommons.org/licenses/by-nc/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc/4.0/88x31.png" /></a><br />
-This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-nc/4.0/">Creative Commons Attribution-NonCommercial 4.0 International License</a>.
+<a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/80x15.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.
+
 
 This project includes the files for INTERMAGNET github organization pages, which are displayed at [https://intermagnet.github.io/](https://intermagnet.github.io/) .
 
@@ -9,6 +9,7 @@ The INTERMAGNET website is available at [http://intermagnet.org/](http://interma
 
 INTERMAGNET members are encouraged to edit this site. For details on how to do this see
 [contributing](CONTRIBUTING.md).
+
 
 ## Examples
 

--- a/license.md
+++ b/license.md
@@ -1,1 +1,1 @@
-<https://creativecommons.org/licenses/by-nc/4.0/>
+https://creativecommons.org/licenses/by/4.0/


### PR DESCRIPTION
After more consideration, I think we may want the website files to be licensed without the non-commercial requirement (CC-BY-4.0).  CC-BY-NC-4.0 is necessary for data, but informational material like the website and technical manual should be usable commercially with attribution.

Thoughts?