### PR TITLE
include GIN emails and link contacts.md from structure.md

### DIFF
--- a/contacts.md
+++ b/contacts.md
@@ -45,3 +45,16 @@ The Operations Committee advises [the Executive Council](#executive-council) on 
 | Tero Raita               | tero.raita@sgo.fi              | Finland                  |
 | Virginie Maury           | vmaury@ipgp.fr                 | France                   |
 
+
+## Geomagnetic Information Nodes
+The GINs are the collection points for data within INTERMAGNET.
+
+| GIN | Manager | Email |
+|---------------|-------|
+| Edinburgh | Simon Flower | e_ginman@mail.nmh.ac.uk |
+| Golden |  Brendan Geels | bgeels@usgs.gov |
+| Kyoto |  Shun Imajo | wdc-service@kugi.kyoto-u.ac.jp  |
+| Ottawa |  Charles Blais | charles.blais@canada.ca |
+| Paris | Virgine Maury | vmaury@ipgp.fr  |
+
+

--- a/structure.md
+++ b/structure.md
@@ -13,6 +13,9 @@ The Executive Council establishes policy for INTERMAGNET, deals with questions o
 - Andrew Lewis (Australia)
 - Jürgen Matzka (Germany)
 
+Contact information is available on the [Contacts](contacts.md#executive-council) page
+
+
 ## Operations Committee
 
 The Operations Committee advises the Executive Council on the technical issues that arise within INTERMAGNET. This includes matters relating to instrumentation, data processing and communications. The Committee is also responsible for establishing and maintaining standards and formats for the global exchange of data under the INTERMAGNET programme, for designing and publishing the INTERMAGNET Technical Manual and producing the annual CD-ROM/DVD.
@@ -47,6 +50,9 @@ The Operations Committee advises the Executive Council on the technical issues t
 | Stephan Bracke | | Member | | Chair | |
 | Tero Raita | Member | | Member | | |
 | Virginie Maury | | Member | | | |
+
+
+Contact information is available on the [Contacts](contacts.md#operations-committee) page
 
 
 ### Data Checking Task Team
@@ -87,3 +93,7 @@ to that GIN.
 | Kyoto | Kyoto University | Shun Imajo
 | Ottawa | Natural Resources Canada | Charles Blais
 | Paris | Institut de Physique du Globe de Paris | Virginie Maury
+
+
+Contact information is available on the [Contacts](contacts.md#geomagnetic-information-nodes) page
+


### PR DESCRIPTION
Included contact information for GINs in contacts.md and added links from structure.md to contacts.md to make it easier to locate contact information.